### PR TITLE
Force an IDR frame when a peer joins.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,14 @@ async fn main() -> Result<()> {
     let display = displays.iter().nth(args.display).unwrap();
     let item = display.create_capture_item_for_monitor()?;
     let mut capture = capture::WGCScreenCapture::new(&item)?;
-    let encoder = Box::new(encoder::X264Encoder::new(
+    let mut encoder = Box::new(encoder::X264Encoder::new(
         display.resolution.0,
         display.resolution.1,
     ));
     let webrtc_output = WebRTCOutput::new(
         WebRTCOutput::make_config(&["stun:stun.l.google.com:19302".into()]),
         Box::new(signaller::WebSocketSignaller::new(&args.url).await?),
+        &mut encoder.force_idr,
     )
     .await?;
     //let file_output = Box::new(FileOutput::new("output.h264"));


### PR DESCRIPTION
This fixes https://mira-screen-share.atlassian.net/browse/MIRA-45.

An IDR frame is a key frame that prevents frames after it from referencing any frames before it. This allows a decoder to start decoding after an IDR frame after the peer joins.