### PR TITLE
Fix DPI-awareness issue by using resolution from GraphicsCaptureItem

### DIFF
--- a/src/capture/display.rs
+++ b/src/capture/display.rs
@@ -1,8 +1,6 @@
 use windows::Graphics::Capture::GraphicsCaptureItem;
 use windows::Win32::Foundation::{BOOL, LPARAM, RECT};
-use windows::Win32::Graphics::Gdi::{
-    EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW,
-};
+use windows::Win32::Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR};
 use windows::Win32::System::WinRT::Graphics::Capture::IGraphicsCaptureItemInterop;
 
 use crate::result::Result;
@@ -10,45 +8,27 @@ use crate::result::Result;
 #[derive(Clone)]
 pub struct DisplayInfo {
     pub handle: HMONITOR,
-    pub display_name: String,
-    pub resolution: (u32, u32),
+}
+
+pub trait Display {
+    /// Get the resolution of the display in (width, height)
+    fn resolution(&self) -> (u32, u32);
 }
 
 impl DisplayInfo {
     pub fn displays() -> Result<Vec<Self>> {
         unsafe {
             let displays = Box::into_raw(Box::new(Vec::<DisplayInfo>::new()));
-            EnumDisplayMonitors(
-                HDC(0),
-                None,
-                Some(enum_monitor),
-                LPARAM(displays as isize),
-            );
+            EnumDisplayMonitors(HDC(0), None, Some(enum_monitor), LPARAM(displays as isize));
             Ok(*Box::from_raw(displays))
         }
     }
 
-    pub fn new(monitor_handle: HMONITOR) -> Result<Self> {
-        let mut info = MONITORINFOEXW::default();
-        info.monitorInfo.cbSize = std::mem::size_of::<MONITORINFOEXW>() as u32;
-
-        unsafe {
-            GetMonitorInfoW(monitor_handle, &mut info as *mut _ as *mut _).ok()?;
-        }
-
-        let display_name = String::from_utf16_lossy(&info.szDevice)
-            .trim_matches(char::from(0))
-            .to_string();
-
-        Ok(Self {
-            handle: monitor_handle,
-            display_name,
-            resolution: ((info.monitorInfo.rcMonitor.right - info.monitorInfo.rcMonitor.left) as u32,
-                         (info.monitorInfo.rcMonitor.bottom - info.monitorInfo.rcMonitor.top) as u32),
-        })
+    pub fn new(handle: HMONITOR) -> Result<Self> {
+        Ok(Self { handle })
     }
 
-    pub fn create_capture_item_for_monitor(&self) -> Result<GraphicsCaptureItem> {
+    pub fn select(&self) -> Result<GraphicsCaptureItem> {
         let interop = windows::core::factory::<GraphicsCaptureItem, IGraphicsCaptureItemInterop>()?;
         Ok(unsafe { interop.CreateForMonitor(self.handle) }?)
     }
@@ -62,4 +42,13 @@ extern "system" fn enum_monitor(monitor: HMONITOR, _: HDC, _: *mut RECT, state: 
         state.push(DisplayInfo::new(monitor).unwrap());
     }
     true.into()
+}
+
+impl Display for GraphicsCaptureItem {
+    fn resolution(&self) -> (u32, u32) {
+        (
+            self.Size().unwrap().Width as u32,
+            self.Size().unwrap().Height as u32,
+        )
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use crate::capture::display::Display;
 use crate::capture::ScreenCapture;
 use crate::encoder::Encoder;
 use crate::output::{FileOutput, OutputSink, WebRTCOutput};
@@ -49,23 +50,12 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    let displays = DisplayInfo::displays()?;
-    for (i, display) in displays.iter().enumerate() {
-        info!(
-            "display: {} {}x{} {}",
-            display.display_name,
-            display.resolution.0,
-            display.resolution.1,
-            if i == args.display { "(selected)" } else { "" },
-        );
-    }
-    let display = displays.iter().nth(args.display).unwrap();
-    let item = display.create_capture_item_for_monitor()?;
+    let display = DisplayInfo::displays()?[args.display].select()?;
     let profiler = PerformanceProfiler::new(args.profiler, args.max_fps);
-    let mut capture = capture::WGCScreenCapture::new(&item)?;
+    let mut capture = capture::WGCScreenCapture::new(&display)?;
     let mut encoder = Box::new(encoder::X264Encoder::new(
-        display.resolution.0,
-        display.resolution.1,
+        display.resolution().0,
+        display.resolution().1,
     ));
     let input_handler = Arc::new(inputs::InputHandler::new());
 


### PR DESCRIPTION
This fixes https://mira-screen-share.atlassian.net/browse/MIRA-80

`GraphicsCaptureItem` should (hopefully) always return the correct resolution regradless of DPI settings and DPI-awareness of the progrem.

Display names are removed because they were not user-friendly name anyways (something like `\.\DISPLAY1`)