### PR TITLE
Add open relay project turn servers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,6 @@ struct Args {
     /// if provided, will stream to file instead of webrtc
     #[arg(long)]
     file: Option<String>,
-    /// ice servers, separated by comma
-    #[arg(long, default_value = "stun:stun.l.google.com:19302")]
-    ice_servers: String,
     /// max fps
     #[arg(long, default_value = "30")]
     max_fps: u32,
@@ -81,7 +78,7 @@ async fn main() -> Result<()> {
         Box::new(FileOutput::new(&path))
     } else {
         WebRTCOutput::new(
-            WebRTCOutput::make_config(args.ice_servers.split(',').map(|s| s.to_string()).collect()),
+            WebRTCOutput::make_config(),
             Box::new(signaller::WebSocketSignaller::new(&args.url, my_uuid).await?),
             &mut encoder.force_idr,
             input_handler.clone(),

--- a/src/output/webrtc_output.rs
+++ b/src/output/webrtc_output.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 use webrtc::api::interceptor_registry::register_default_interceptors;
 use webrtc::api::media_engine::MediaEngine;
 use webrtc::api::APIBuilder;
+use webrtc::ice_transport::ice_credential_type::RTCIceCredentialType::Password;
 use webrtc::ice_transport::ice_server::RTCIceServer;
 use webrtc::interceptor::registry::Registry;
 use webrtc::peer_connection::configuration::RTCConfiguration;
@@ -23,12 +24,21 @@ pub struct WebRTCOutput {
 }
 
 impl WebRTCOutput {
-    pub fn make_config(ice_servers: Vec<String>) -> RTCConfiguration {
+    pub fn make_config() -> RTCConfiguration {
         RTCConfiguration {
-            ice_servers: vec![RTCIceServer {
-                urls: ice_servers,
-                ..Default::default()
-            }],
+            ice_servers: vec![
+                RTCIceServer {
+                    urls: vec!["stun:stun.l.google.com:19302".to_string()],
+                    ..Default::default()
+                },
+                RTCIceServer {
+                    // TURN server from [Open Relay Project](https://openrelayproject.org)
+                    urls: vec!["turn:openrelay.metered.ca:80".to_string()],
+                    username: "openrelayproject".to_string(),
+                    credential: "openrelayproject".to_string(),
+                    credential_type: Password,
+                },
+            ],
             ..Default::default()
         }
     }


### PR DESCRIPTION
Turns out that you can't fully specify a ice server in a string so `ice_servers` param is removed and later we want to add a json/toml file specifying ice servers. For now, [Open Relay Project](https://www.metered.ca/tools/openrelay/)'s TURN servers are hardcoded as the default ICE servers.