### PR TITLE
Disable remote control

### DIFF
--- a/src/capture/macos/display.rs
+++ b/src/capture/macos/display.rs
@@ -2,7 +2,6 @@ use failure::format_err;
 
 use crate::capture::DisplayInfo;
 use crate::result::Result;
-use failure::format_err;
 use std::mem;
 
 use super::ffi::*;

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -38,7 +38,6 @@ enum InputMessage {
 
 pub struct InputHandler {
     pub sender: mpsc::Sender<Bytes>,
-    pub remote_control: bool,
 }
 
 impl InputHandler {
@@ -79,6 +78,6 @@ impl InputHandler {
                 }
             }
         });
-        Self { sender, remote_control: disabled_control }
+        Self { sender }
     }
 }

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -38,6 +38,7 @@ enum InputMessage {
 
 pub struct InputHandler {
     pub sender: mpsc::Sender<Bytes>,
+    pub remote_control: bool,
 }
 
 impl InputHandler {
@@ -45,6 +46,7 @@ impl InputHandler {
         let mut enigo = enigo::Enigo::new();
         let input_msg = serde_json::from_slice::<InputMessage>(&input_msg)?;
         debug!("Deserialized input message: {:#?}", input_msg);
+        /// Only make remote control effective if the user has explicitly enabled it
         match input_msg {
             InputMessage::KeyDown { key } => enigo.key_down(enigo::Key::from_js_key(&key)?),
             InputMessage::KeyUp { key } => enigo.key_up(enigo::Key::from_js_key(&key)?),
@@ -66,15 +68,17 @@ impl InputHandler {
         Ok(())
     }
 
-    pub fn new() -> Self {
+    pub fn new(control: bool) -> Self {
         let (sender, mut receiver) = mpsc::channel::<Bytes>(32);
         tokio::spawn(async move {
-            while let Some(msg) = receiver.recv().await {
-                if let Err(err) = Self::handle_input_event(msg) {
-                    warn!("Error handling input event: {}", err);
+            if control {
+                while let Some(msg) = receiver.recv().await {
+                    if let Err(err) = Self::handle_input_event(msg) {
+                        warn!("Error handling input event: {}", err);
+                    }
                 }
             }
         });
-        Self { sender }
+        Self { sender, remote_control: control }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,9 @@ struct Args {
     /// Config file path
     #[arg(short, long, default_value = "config.toml")]
     config: String,
-    /// Enable remote control
+    /// Disable remote control
     #[arg(long, default_value = "false")]
-    remote_control: bool,
+    disable_control: bool,
 }
 
 #[tokio::main]
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
     let resolution = display.resolution();
     let mut capture = ScreenCaptureImpl::new(display, &config)?;
     let mut encoder = encoder::FfmpegEncoder::new(resolution.0, resolution.1, &config.encoder);
-    let input_handler = Arc::new(inputs::InputHandler::new(args.remote_control));
+    let input_handler = Arc::new(inputs::InputHandler::new(args.disable_control));
     let my_uuid = uuid::Uuid::new_v4().to_string();
 
     info!("Resolution: {:?}", resolution);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ struct Args {
     /// Config file path
     #[arg(short, long, default_value = "config.toml")]
     config: String,
+    /// Enable remote control
+    #[arg(long, default_value = "false")]
+    remote_control: bool,
 }
 
 #[tokio::main]
@@ -51,7 +54,7 @@ async fn main() -> Result<()> {
     let resolution = display.resolution();
     let mut capture = ScreenCaptureImpl::new(display, &config)?;
     let mut encoder = encoder::FfmpegEncoder::new(resolution.0, resolution.1, &config.encoder);
-    let input_handler = Arc::new(inputs::InputHandler::new());
+    let input_handler = Arc::new(inputs::InputHandler::new(args.remote_control));
     let my_uuid = uuid::Uuid::new_v4().to_string();
 
     info!("Resolution: {:?}", resolution);


### PR DESCRIPTION
Remote control is enabled by default unless Sharer specifies it in the command line. 
eg.  cargo run --release -- --display 0 --disable-control