### PR TITLE
Fix sender.try_send.unwrap() Panicking on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.dll
 /config.toml
 **/.DS_Store
+third_party
+*.exe

--- a/src/capture/wgc/wgc_capture.rs
+++ b/src/capture/wgc/wgc_capture.rs
@@ -70,7 +70,11 @@ impl ScreenCapture for WGCScreenCapture<'_> {
             move |frame_pool, _| {
                 let frame_pool = frame_pool.as_ref().unwrap();
                 let frame = frame_pool.TryGetNextFrame()?;
-                sender.try_send(frame).unwrap_or(());
+                sender
+                    .try_send(frame)
+                    .unwrap_or_else(move |err|
+                        warn!("Failed to send frame: {}", err.to_string())
+                    );
                 Ok(())
             }
         }))?;

--- a/src/capture/wgc/wgc_capture.rs
+++ b/src/capture/wgc/wgc_capture.rs
@@ -70,7 +70,7 @@ impl ScreenCapture for WGCScreenCapture<'_> {
             move |frame_pool, _| {
                 let frame_pool = frame_pool.as_ref().unwrap();
                 let frame = frame_pool.TryGetNextFrame()?;
-                sender.try_send(frame).unwrap();
+                sender.try_send(frame).unwrap_or(());
                 Ok(())
             }
         }))?;

--- a/src/gui/theme/button/fab.rs
+++ b/src/gui/theme/button/fab.rs
@@ -1,7 +1,6 @@
 use iced::{Background, Color};
 use iced::widget::{button, horizontal_space, row, text};
 use iced::widget::button::{Appearance, StyleSheet};
-use crate::gui::resource;
 
 use crate::gui::theme::button::{Buildable, Style, Themed};
 use crate::gui::theme::button::Style::{Danger, Primary, Secondary};


### PR DESCRIPTION
`sender.try_send.unwrap()` may panic on screen capture termination because
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Closed(Direct3D11CaptureFrame(IUnknown(0x22e15972b90)))', src\capture\wgc\wgc_capture.rs:73:40
```
with `Err(TrySendError::Closed)`.

From `try_send`'s doc:
```
    /// If the receive half of the channel is closed, either due to [`close`]
    /// being called or the [`Receiver`] handle dropping, the function returns
    /// an error. The error includes the value passed to `send`.
```
So the receiver is dropped before sender, and `try_send` is invoked in between.

## How is this tested
By repeatedly starting and stopping capture, this can be easily reproduced before and have not yet been reproduced after the change. Through logging, this seems to only be encountered once, so we should be fine ignoring:
```
[2023-06-16T23:52:04Z INFO  iced_wgpu::image::atlas] Deallocating atlas: Partial { layer: 0, region: Region { id: AllocId(16777221), rectangle: Box2D((32, 0), (54, 27)) } }
[2023-06-16T23:52:04Z INFO  mira_sharer::performance_profiler] Total time 12.3ms (4.0 p, 8.3 e, 0.0 s) 79.9% at 65 FPS. Current FPS: 0/81.3. 0.0 kbps
[2023-06-16T23:52:04Z WARN  mira_sharer::capture::wgc::wgc_capture] Failed to send frame: channel closed
[libx264 @ 000001ed88446300] frame I:1     Avg QP:20.00  size:665100
[libx264 @ 000001ed88446300] frame P:6     Avg QP:24.50  size: 51531
[libx264 @ 000001ed88446300] mb I  I16..4: 100.0%  0.0%  0.0%
```