### PR TITLE
Migrate from failure to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,28 +1678,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3001,7 @@ name = "mira_sharer"
 version = "0.1.0"
 dependencies = [
  "ac-ffmpeg",
+ "anyhow",
  "async-trait",
  "block",
  "bytes",
@@ -3027,7 +3012,6 @@ dependencies = [
  "embed-resource",
  "enigo",
  "env_logger 0.10.0",
- "failure",
  "futures-util",
  "howlong",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-failure = "0.1.8"
+anyhow = "1.0"
 clap = { version = "4.0.14", features = ["derive"] }
 tokio = { version = "1.15", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/src/capture/audio/mod.rs
+++ b/src/capture/audio/mod.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{SampleFormat, Stream};
 
+use anyhow::anyhow;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -127,7 +128,7 @@ impl AudioCapture {
                 None,
             )?,
             _ => {
-                return Err(failure::err_msg("unsupported sample format"));
+                return Err(anyhow!("unsupported sample format"));
             }
         };
 

--- a/src/capture/macos/display.rs
+++ b/src/capture/macos/display.rs
@@ -1,6 +1,6 @@
 use crate::capture::DisplayInfo;
 use crate::result::Result;
-use failure::format_err;
+use anyhow::format_err;
 
 use super::ffi::*;
 

--- a/src/capture/macos/macos_capture.rs
+++ b/src/capture/macos/macos_capture.rs
@@ -1,10 +1,10 @@
+use std::sync::Arc;
 use std::time::Duration;
 use std::{ptr, slice};
-use std::sync::Arc;
 
+use anyhow::format_err;
 use async_trait::async_trait;
 use block::{Block, ConcreteBlock};
-use failure::format_err;
 use libc::c_void;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;

--- a/src/inputs/parse_key.rs
+++ b/src/inputs/parse_key.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use failure::format_err;
+use anyhow::format_err;
 
 pub trait FromJsKey {
     /// convert from KeyboardEvent.code

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,3 @@
-use failure::Error;
+use anyhow::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Failure was [deprecated](https://github.com/rust-lang-deprecated/failure/pull/347).